### PR TITLE
Update pickList.js - blur event documentation

### DIFF
--- a/src/widgets/select/pickList.js
+++ b/src/widgets/select/pickList.js
@@ -159,7 +159,7 @@
       /**
        * Fired when the pickList loses focus
        *
-       * @event focus
+       * @event blur
        */
       blur: null
     },


### PR DESCRIPTION
There was focus instead of blur in the blur event docs.
