### PR TITLE
clean up bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,23 +2,26 @@
   "name": "richwidgets",
   "version": "0.0.1-SNAPSHOT",
   "dependencies": {
+  },
+  "devDependencies": {
+
     "jquery": "~1.9.0",
     "jquery-ui": "~1.9.2",
     "bootstrap": "3.0.0",
     "font-awesome": "~3.2.1",
-    "modernizr": "~2.6.2",
-    "highlightjs": "~7.3.0",
-    "lodash": "~1.3.1",
     "flot" : "0.8.0",
     "flotAxisLabels":"https://github.com/markrcote/flot-axislabels.git",
     "flotTooltip":"https://github.com/krzysu/flot.tooltip.git",
-    "flotOrderBars":"https://github.com/emmerich/flot-orderBars.git"
-  },
-  "devDependencies": {
+    "flotOrderBars":"https://github.com/emmerich/flot-orderBars.git",
+
     "requirejs": "~2.1.8",
     "jasmine-jquery": "~1.5.3",
     "dom-compare": "lfryc/dom-compare#requirejs",
     "jquery-simulate": "*",
+
+    "modernizr": "~2.6.2",
+    "highlightjs": "~7.3.0",
+
     "yuidoc-bootstrap-theme": "https://github.com/richwidgets/yuidoc-bootstrap-theme.git"
   }
 }


### PR DESCRIPTION
I have moved all the dependencies into `devDependencies` section.

They are splitted into logical groups, but unfortunately bower doesn't allow comments (in fact well-formed JSON can't contain any comments).
