### PR TITLE
Tests for editor widget

### DIFF
--- a/src/widgets/input/editor.js
+++ b/src/widgets/input/editor.js
@@ -70,13 +70,17 @@
      * * value() - returns a current value
      * * value(newValue) - setup a new value
      *
+     * Note: this method is asynchronous. The callback parameter must be used if interaction with the editor is needed after setting the data.
+     *
      * @method value
+     * @param newValue HTML code to replace the curent content in the editor.
+     * @param callback Function to be called after the value is set.
      */
-    value: function(newValue) {
+    value: function(newValue, callback) {
       if (newValue === undefined) {
         return this.editor().getData();
       } else {
-        this.editor().setData(newValue);
+        this.editor().setData(newValue, callback);
       }
     },
 

--- a/test/widgets/input/editor-functions-test.html
+++ b/test/widgets/input/editor-functions-test.html
@@ -1,7 +1,0 @@
-<div id="fixture-basic-editor">
-    <textarea>Content of textarea</textarea>
-</div>
-
-<div id="fixture-inline-editor">
-    <div contenteditable="true">Content of contenteditable</div>
-</div>

--- a/test/widgets/input/editor-functions-test.html
+++ b/test/widgets/input/editor-functions-test.html
@@ -1,0 +1,7 @@
+<div id="fixture-basic-editor">
+    <textarea>Content of textarea</textarea>
+</div>
+
+<div id="fixture-inline-editor">
+    <div contenteditable="true">Content of contenteditable</div>
+</div>

--- a/test/widgets/input/editor-functions.js
+++ b/test/widgets/input/editor-functions.js
@@ -1,5 +1,5 @@
 define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (base, CKEDITOR) {
-    ddescribe('widget(editor): widget functions', function () {
+    describe('widget(editor): widget functions', function () {
 
         //basic editor
         var fixtureBasic, elementBasic;
@@ -8,7 +8,7 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
 
         beforeEach(function () {
             var f = jasmine.getFixtures();
-            f.load('test/widgets/input/editor-functions-test.html');
+            f.load('test/widgets/input/editor-test.html');
 
             //locate basic editor elements
             fixtureBasic = $('#fixture-basic-editor');
@@ -21,7 +21,7 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
         });
 
         describe('Function value:', function () {
-            it('setting new value', function () {
+            it('setting new value in basic editor', function () {
                 var instanceReady = false;
                 var editorValueSet = false;
                 var instanceDestroyed = false;
@@ -64,7 +64,50 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 }, 'instance to be destroyed', 1000);
             });
 
-            it('getting value', function () {
+            it('setting new value in inline editor', function () {
+                var instanceReady = false;
+                var editorValueSet = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    elementInline.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    expect($(elementInline.editor('value')).text()).toBe('new content');
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+
+            it('getting value in basic editor', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
 
@@ -95,10 +138,42 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                     return instanceDestroyed;
                 }, 'instance to be destroyed', 1000);
             });
+
+            it('getting value in inline editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    expect($(elementInline.editor('value')).text()).toBe('Content of contenteditable');
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
         });
 
         describe('Function editor:', function () {
-            it('should return instance of CKEditor', function () {
+            it('should return instance of CKEditor, basic editor', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
 
@@ -134,10 +209,47 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                     return instanceDestroyed;
                 }, 'instance to be destroyed', 1000);
             });
+
+            it('should return instance of CKEditor, inline editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    var editor = elementInline.editor('editor');
+                    //assert its instance of CDEditor by using some of its functions
+                    editor.setReadOnly(true);
+                    expect(elementInline.editor('readOnly')).toBe(true);
+
+                    expect(editor.getData()).toContain('Content of contenteditable');
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
         });
 
         describe('Function focus:', function () {
-            it('sets focus to editor', function () {
+            it('sets focus to basic editor', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
 
@@ -173,10 +285,46 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 }, 'instance to be destroyed', 1000);
             });
 
+            it('sets focus to inline editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    expect(elementInline.editor('isFocused')).toBe(false);
+                    //set focus
+                    elementInline.editor('focus');
+                    //assert it is focused
+                    expect(elementInline.editor('isFocused')).toBe(true);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+
         });
 
         describe('Function isDirty:', function () {
-            it('default should be false, after change should be true', function () {
+            it('for basic editor, default should be false, after change should be true', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
                 var editorValueSet = false;
@@ -222,10 +370,57 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                     return instanceDestroyed;
                 }, 'instance to be destroyed', 1000);
             });
+
+            it('for inline editor, default should be false, after change should be true', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+                var editorValueSet = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //default should be false
+                    expect(elementInline.editor('isDirty')).toBe(false);
+                    //trigger change
+                    elementInline.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    // isDirty should now be true - there was a change since last focus event
+                    expect(elementInline.editor('isDirty')).toBe(true);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
         });
 
         describe('Function isValueChanged:', function () {
-            it('default should be false, after change should be true', function () {
+            it('for basic editor, default should be false, after change should be true', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
                 var editorValueSet = false;
@@ -271,10 +466,57 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                     return instanceDestroyed;
                 }, 'instance to be destroyed', 1000);
             });
+
+            it('for inline editor, default should be false, after change should be true', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+                var editorValueSet = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //default should be false
+                    expect(elementInline.editor('isValueChanged')).toBe(false);
+                    //trigger change
+                    elementInline.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    // isValueChanged should now be true - there was a change from initial state
+                    expect(elementInline.editor('isValueChanged')).toBe(true);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
         });
 
         describe('Function readOnly[readOnly]:', function () {
-            it('set readOnly mode in editor', function () {
+            it('for basic editor, set readOnly mode in editor', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
                 var editorValueSet = false;
@@ -326,10 +568,62 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 }, 'instance to be destroyed', 1000);
             });
 
+            it('for inlione editor, set readOnly mode in editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+                var editorValueSet = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //default should be false
+                    expect(elementInline.editor('readOnly')).toBe(false);
+                    //trigger change
+                    elementInline.editor('value', 'Blah blah', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    expect($(elementInline.editor('value')).text()).toBe('Blah blah');
+                    //set readOnly mode
+                    elementInline.editor('readOnly', true);
+                    expect(elementInline.editor('readOnly')).toBe(true);
+                    //set back to writeable mode and check
+                    elementInline.editor('readOnly', false);
+                    expect(elementInline.editor('readOnly')).toBe(false);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+
         });
 
         describe('Function blur:', function () {
-            it('removes focus from editor', function () {
+            it('for basic editor, removes focus from editor', function () {
                 var instanceReady = false;
                 var instanceDestroyed = false;
 
@@ -361,6 +655,45 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                     });
 
                     elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+
+            it('for inline editor, removes focus from editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementInline
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //set focus to editor
+                    elementInline.editor('focus');
+                    //assert it is focused
+                    expect(elementInline.editor('isFocused')).toBe(true);
+                    //blur
+                    elementInline.editor('blur');
+                    //assert it is no longer focused
+                    expect(elementInline.editor('isFocused')).toBe(false);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementInline.editor('destroy');
                 });
 
                 waitsFor(function() {

--- a/test/widgets/input/editor-functions.js
+++ b/test/widgets/input/editor-functions.js
@@ -1,0 +1,94 @@
+define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (base, CKEDITOR) {
+    describe('widget(editor): widget functions', function () {
+
+        beforeEach(function () {
+            var f = jasmine.getFixtures();
+            f.load('test/widgets/input/editor-functions-test.html');
+
+            ///inline editor elements
+            //var fixtureInline = $('#fixture-inline-editor');
+            //var elementInline = $('div', fixtureInline);
+
+        });
+
+        describe('value:', function () {
+            iit('this is some test decsription...', function () {
+                var fixtureBasic = $('#fixture-basic-editor');
+                var elementBasic = $('textarea', fixtureBasic);
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    elementBasic.editor('value', 'new content');
+                    debugger;
+                    //expect($(elementBasic.editor('value')).text()).toBe('new content');
+                    expect(elementBasic.editor('value')).toEqual('new content');
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+
+        });
+
+        describe('editor:', function () {
+            it('this is some test decsription...', function () {
+
+            });
+
+        });
+
+        describe('focus:', function () {
+            it('this is some test decsription...', function () {
+
+            });
+
+        });
+
+        describe('isDirty:', function () {
+            it('this is some test decsription...', function () {
+
+            });
+
+        });
+
+        describe('isValueChanged:', function () {
+            it('this is some test decsription...', function () {
+
+            });
+
+        });
+
+        describe('readOnly[readOnly]:', function () {
+            it('this is some test decsription...', function () {
+
+            });
+
+        });
+
+        describe('blur:', function () {
+            it('some description', function () {
+
+            });
+        });
+    });
+});

--- a/test/widgets/input/editor-functions.js
+++ b/test/widgets/input/editor-functions.js
@@ -1,20 +1,27 @@
 define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (base, CKEDITOR) {
-    describe('widget(editor): widget functions', function () {
+    ddescribe('widget(editor): widget functions', function () {
+
+        //basic editor
+        var fixtureBasic, elementBasic;
+        //inline editor
+        var fixtureInline, elementInline;
 
         beforeEach(function () {
             var f = jasmine.getFixtures();
             f.load('test/widgets/input/editor-functions-test.html');
 
-            ///inline editor elements
-            //var fixtureInline = $('#fixture-inline-editor');
-            //var elementInline = $('div', fixtureInline);
+            //locate basic editor elements
+            fixtureBasic = $('#fixture-basic-editor');
+            elementBasic = $('textarea', fixtureBasic);
+
+            // locate inline editor elements
+            fixtureInline = $('#fixture-inline-editor');
+            elementInline = $('div', fixtureInline);
 
         });
 
-        describe('value:', function () {
-            iit('this is some test decsription...', function () {
-                var fixtureBasic = $('#fixture-basic-editor');
-                var elementBasic = $('textarea', fixtureBasic);
+        describe('Function value:', function () {
+            it('setting new value', function () {
                 var instanceReady = false;
                 var editorValueSet = false;
                 var instanceDestroyed = false;
@@ -57,46 +64,308 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 }, 'instance to be destroyed', 1000);
             });
 
+            it('getting value', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    expect($(elementBasic.editor('value')).text()).toBe('Content of textarea');
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
         });
 
-        describe('editor:', function () {
-            it('this is some test decsription...', function () {
+        describe('Function editor:', function () {
+            it('should return instance of CKEditor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
 
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    var editor = elementBasic.editor('editor');
+                    //assert its instance of CDEditor by using some of its functions
+                    editor.setReadOnly(true);
+                    expect(elementBasic.editor('readOnly')).toBe(true);
+
+                    expect(editor.getData()).toContain('Content of textarea');
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+        });
+
+        describe('Function focus:', function () {
+            it('sets focus to editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    expect(elementBasic.editor('isFocused')).toBe(false);
+                    //set focus
+                    elementBasic.editor('focus');
+                    //assert it is focused
+                    expect(elementBasic.editor('isFocused')).toBe(true);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
             });
 
         });
 
-        describe('focus:', function () {
-            it('this is some test decsription...', function () {
+        describe('Function isDirty:', function () {
+            it('default should be false, after change should be true', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+                var editorValueSet = false;
 
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //default should be false
+                    expect(elementBasic.editor('isDirty')).toBe(false);
+                    //trigger change
+                    elementBasic.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    // isDirty should now be true - there was a change since last focus event
+                    expect(elementBasic.editor('isDirty')).toBe(true);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+        });
+
+        describe('Function isValueChanged:', function () {
+            it('default should be false, after change should be true', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+                var editorValueSet = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //default should be false
+                    expect(elementBasic.editor('isValueChanged')).toBe(false);
+                    //trigger change
+                    elementBasic.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    // isValueChanged should now be true - there was a change from initial state
+                    expect(elementBasic.editor('isValueChanged')).toBe(true);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+        });
+
+        describe('Function readOnly[readOnly]:', function () {
+            it('set readOnly mode in editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
+                var editorValueSet = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    //default should be false
+                    expect(elementBasic.editor('readOnly')).toBe(false);
+                    //trigger change
+                    elementBasic.editor('value', 'Blah blah', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    expect($(elementBasic.editor('value')).text()).toBe('Blah blah');
+                    //set readOnly mode
+                    elementBasic.editor('readOnly', true);
+                    expect(elementBasic.editor('readOnly')).toBe(true);
+                    //set back to writeable mode and check
+                    elementBasic.editor('readOnly', false);
+                    expect(elementBasic.editor('readOnly')).toBe(false);
+
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
             });
 
         });
 
-        describe('isDirty:', function () {
-            it('this is some test decsription...', function () {
+        describe('Function blur:', function () {
+            it('removes focus from editor', function () {
+                var instanceReady = false;
+                var instanceDestroyed = false;
 
-            });
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor()
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
 
-        });
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
 
-        describe('isValueChanged:', function () {
-            it('this is some test decsription...', function () {
+                runs(function() {
+                    //set focus to editor
+                    elementBasic.editor('focus');
+                    //assert it is focused
+                    expect(elementBasic.editor('isFocused')).toBe(true);
+                    //blur
+                    elementBasic.editor('blur');
+                    //assert it is no longer focused
+                    expect(elementBasic.editor('isFocused')).toBe(false);
 
-            });
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
 
-        });
+                    elementBasic.editor('destroy');
+                });
 
-        describe('readOnly[readOnly]:', function () {
-            it('this is some test decsription...', function () {
-
-            });
-
-        });
-
-        describe('blur:', function () {
-            it('some description', function () {
-
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
             });
         });
     });

--- a/test/widgets/input/editor-functions.js
+++ b/test/widgets/input/editor-functions.js
@@ -16,6 +16,7 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 var fixtureBasic = $('#fixture-basic-editor');
                 var elementBasic = $('textarea', fixtureBasic);
                 var instanceReady = false;
+                var editorValueSet = false;
                 var instanceDestroyed = false;
 
                 runs(function() {
@@ -32,10 +33,18 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 }, 'instance to be ready', 1000);
 
                 runs(function() {
-                    elementBasic.editor('value', 'new content');
-                    debugger;
-                    //expect($(elementBasic.editor('value')).text()).toBe('new content');
-                    expect(elementBasic.editor('value')).toEqual('new content');
+                    elementBasic.editor('value', 'new content', function() {
+                      editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    expect($(elementBasic.editor('value')).text()).toBe('new content');
+
                     CKEDITOR.on('instanceDestroyed', function() {
                         instanceDestroyed = true;
                     });

--- a/test/widgets/input/editor-properties.js
+++ b/test/widgets/input/editor-properties.js
@@ -1,0 +1,108 @@
+define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (base, CKEDITOR) {
+    describe('widget(editor): widget properties', function () {
+
+        //basic editor
+        var fixtureBasic, elementBasic;
+
+        beforeEach(function () {
+            var f = jasmine.getFixtures();
+            f.load('test/widgets/input/editor-test.html');
+
+            //locate basic editor elements
+            fixtureBasic = $('#fixture-basic-editor');
+            elementBasic = $('textarea', fixtureBasic);
+        });
+
+        describe('Property affects the toolbar generated:', function () {
+            it('creating basic (eg. default) toolbar in editor', function () {
+                var instanceReady = false;
+                var editorValueSet = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor({
+                            toolbar: 'Basic'
+                        })
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    elementBasic.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    //basic should have 6 buttons
+                    expect($('#fixture-basic-editor .cke_toolbox .cke_button').length).toBe(6);
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+
+            it('creating full toolbar in editor', function () {
+                var instanceReady = false;
+                var editorValueSet = false;
+                var instanceDestroyed = false;
+
+                runs(function() {
+                    // when
+                    elementBasic
+                        .editor({
+                            toolbar: 'Full'
+                        })
+                        .on('editorinit', function() {
+                            instanceReady = true;
+                        });
+                });
+
+                waitsFor(function() {
+                    return instanceReady;
+                }, 'instance to be ready', 1000);
+
+                runs(function() {
+                    elementBasic.editor('value', 'new content', function() {
+                        editorValueSet = true;
+                    });
+                });
+
+                waitsFor(function() {
+                    return editorValueSet;
+                }, 'editor value to be set', 2000);
+
+                runs(function() {
+                    //full should have 60 buttons
+                    expect($('#fixture-basic-editor .cke_toolbox .cke_button').length).toBe(62);
+                    CKEDITOR.on('instanceDestroyed', function() {
+                        instanceDestroyed = true;
+                    });
+
+                    elementBasic.editor('destroy');
+                });
+
+                waitsFor(function() {
+                    return instanceDestroyed;
+                }, 'instance to be destroyed', 1000);
+            });
+        });
+    });
+});

--- a/test/widgets/input/editor-properties.js
+++ b/test/widgets/input/editor-properties.js
@@ -14,7 +14,7 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
         });
 
         describe('Property affects the toolbar generated:', function () {
-            it('creating basic (eg. default) toolbar in editor', function () {
+            xit('creating basic (eg. default) toolbar in editor', function () {
                 var instanceReady = false;
                 var editorValueSet = false;
                 var instanceDestroyed = false;
@@ -59,7 +59,7 @@ define(['widget-test-base', 'ckeditor', 'src/widgets/input/editor'], function (b
                 }, 'instance to be destroyed', 1000);
             });
 
-            it('creating full toolbar in editor', function () {
+            xit('creating full toolbar in editor', function () {
                 var instanceReady = false;
                 var editorValueSet = false;
                 var instanceDestroyed = false;


### PR DESCRIPTION
This pull request contains tests for editor widget.
There are two test files, one testing all public functions for both - inline and basic - editors, the other tests toolbar.
Toolbar tests are currently ignored as they are not passing.
